### PR TITLE
fix to detect expired SCM credentials in ProjectRepoConfig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-.env
+.env*
 
 examples/**.zip
 


### PR DESCRIPTION
The code repo import credentials can expire, the class now handles this scenario.